### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+gwaei (3.6.2-10) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on debhelper.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 24 Aug 2021 18:09:52 -0000
+
 gwaei (3.6.2-9) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: gwaei
 Section: gnome
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
-Build-Depends: libcurl4-gnutls-dev | libcurl4-openssl-dev, libgtk-3-dev (>= 3.3.0), yelp-tools, debhelper (>= 10~), libncurses5-dev, libncursesw5-dev, imagemagick, intltool, gsettings-desktop-schemas, libhunspell-dev, libmecab-dev
+Build-Depends: libcurl4-gnutls-dev | libcurl4-openssl-dev, libgtk-3-dev (>= 3.3.0), yelp-tools, debhelper, libncurses5-dev, libncursesw5-dev, imagemagick, intltool, gsettings-desktop-schemas, libhunspell-dev, libmecab-dev
 Standards-Version: 4.2.1
 Homepage: http://www.zacharydovel.com/software/gwaei
 Vcs-Browser: https://github.com/norbusan/debian-gwaei


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/gwaei/3ec25fe3-8449-4483-87ff-869d194eff23.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/19/0121ad1633bd8f3b6fe6d4912d090aa0d4ccc2.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/33/1eba106f2d24df7bbaccdefddf7f1f8b50b025.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/bb/f5c4d0107a427908cefcb0185321edd6ccf632.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fa/335665ea3a74009bedde6c6e95d0d9aa1901f0.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/37/1a9be84734b919e652078306ad55c3acfe39f3.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/88/4e201777c98be74df5b1c45614547e21f57851.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/da/75c10d48e961cf84d551f9784ba2d70dbf9cf6.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/f6/fb201ceaa076cbdc2a9b81687121a237fbfbb6.debug
### Control files of package gwaei: lines which differ (wdiff format)
* Depends: libc6 (>= 2.7), libcairo2 (>= 1.2.4), [-libgdk-pixbuf2.0-0-] {+libgdk-pixbuf-2.0-0+} (>= 2.22.0), libglib2.0-0 (>= 2.37.3), libgtk-3-0 (>= 3.3.16), libhunspell-1.7-0, libpango-1.0-0 (>= 1.20.0), libpangocairo-1.0-0 (>= 1.14.0), libwaei2
### Control files of package gwaei-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-884e201777c98be74df5b1c45614547e21f57851 da75c10d48e961cf84d551f9784ba2d70dbf9cf6 f6fb201ceaa076cbdc2a9b81687121a237fbfbb6-] {+190121ad1633bd8f3b6fe6d4912d090aa0d4ccc2 331eba106f2d24df7bbaccdefddf7f1f8b50b025 fa335665ea3a74009bedde6c6e95d0d9aa1901f0+}

No differences were encountered between the control files of package \*\*libwaei-dev\*\*
### Control files of package libwaei2: lines which differ (wdiff format)
* Depends: libc6 (>= 2.2.5), libcurl3-gnutls (>= 7.16.2), libglib2.0-0 (>= 2.37.3), [-libmecab2,-] {+libmecab2 (>= 0.996),+} zlib1g (>= 1:1.1.4)
### Control files of package libwaei2-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-371a9be84734b919e652078306ad55c3acfe39f3-] {+bbf5c4d0107a427908cefcb0185321edd6ccf632+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/3ec25fe3-8449-4483-87ff-869d194eff23/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/3ec25fe3-8449-4483-87ff-869d194eff23/diffoscope)).
